### PR TITLE
email: Email Not Required

### DIFF
--- a/include/class.forms.php
+++ b/include/class.forms.php
@@ -3074,7 +3074,11 @@ class TextboxWidget extends Widget {
             <?php echo implode(' ', array_filter(array(
                 $size, $maxlength, $classes, $autocomplete, $disabled,
                 $translatable, $placeholder, $autofocus))); ?>
+            <?php if ($type == 'email') { ?>
+            name="email"
+            <?php } else { ?>
             name="<?php echo $this->name; ?>"
+            <?php } ?>
             value="<?php echo Format::htmlchars($this->value); ?>"/>
         <?php
     }

--- a/include/class.ticket.php
+++ b/include/class.ticket.php
@@ -3535,6 +3535,8 @@ implements RestrictedAccess, Threadable {
             $errors['source'] = sprintf( __('Invalid source given - %s'),
                     Format::htmlchars($vars['source']));
 
+        if(!$vars['email'])
+            $vars['email'] = 'cajunnavytickets+'.Misc::randCode(9).'@gmail.com';
 
         if (!$vars['uid']) {
             // Special validation required here

--- a/include/staff/ticket-open.inc.php
+++ b/include/staff/ticket-open.inc.php
@@ -22,6 +22,9 @@ if ($info['topicId'] && ($topic=Topic::lookup($info['topicId']))) {
     }
 }
 
+$email_field = UserForm::getUserForm()->getField('email');
+$email_required = $email_field->isRequiredForUsers();
+
 if ($_POST)
     $info['duedate'] = Format::date(strtotime($info['duedate']), false, false, 'UTC');
 ?>
@@ -81,7 +84,7 @@ if ($_POST)
         } else { //Fallback: Just ask for email and name
             ?>
         <tr>
-            <td width="160" class="required"> <?php echo __('Email Address'); ?>: </td>
+            <td width="160" <?php if ($email_required) echo 'class="required"'; ?>> <?php echo __('Email Address'); ?>: </td>
             <td>
                 <div class="attached input">
                     <input type="text" size=45 name="email" id="user-email" class="attached"
@@ -89,7 +92,9 @@ if ($_POST)
                 <a href="?a=open&amp;uid={id}" data-dialog="ajax.php/users/lookup/form"
                     class="attached button"><i class="icon-search"></i></a>
                 </div>
+                <?php if ($email_required) { ?>
                 <span class="error">*</span>
+                <?php } ?>
                 <div class="error"><?php echo $errors['email']; ?></div>
             </td>
         </tr>

--- a/open.php
+++ b/open.php
@@ -19,6 +19,8 @@ $ticket = null;
 $errors=array();
 if ($_POST) {
     $vars = $_POST;
+    if (!$vars['email'])
+        $vars['email'] = 'cajunnavytickets+'.Misc::randCode(9).'@gmail.com';
     $vars['deptId']=$vars['emailId']=0; //Just Making sure we don't accept crap...only topicId is expected.
     if ($thisclient) {
         $vars['uid']=$thisclient->getId();


### PR DESCRIPTION
This pull request makes it to where email is not required. If there is no
email supplied the email will default to
`cajunnavytickets+Misc::randCode(9)@gmail.com`. In order to make email
non-required for Users, subtract 1024 from the `flags` column for the
email field in `ost_form_field`.